### PR TITLE
Terrain commands, keybind protection, puke

### DIFF
--- a/src/CommandHandler.cs
+++ b/src/CommandHandler.cs
@@ -845,7 +845,7 @@ namespace Gungnir
                 return;
             }
 
-            Ground.Lower(Player.m_localPlayer.transform.position, radius, depth);
+            Ground.Lower(Player.m_localPlayer.transform.position, radius, depth, strength);
             Logger.Log($"Terrain within {radius.ToString().WithColor(Logger.GoodColor)} meter(s) lowered.", true);
         }
 
@@ -889,7 +889,7 @@ namespace Gungnir
                 return;
             }
 
-            Ground.Raise(Player.m_localPlayer.transform.position, radius, height);
+            Ground.Raise(Player.m_localPlayer.transform.position, radius, height, strength);
             Logger.Log($"Terrain within {radius.ToString().WithColor(Logger.GoodColor)} meter(s) raised.", true);
         }
 

--- a/src/CommandHandler.cs
+++ b/src/CommandHandler.cs
@@ -1394,7 +1394,7 @@ namespace Gungnir
                 mod.m_settings.m_raise = true;
                 mod.m_settings.m_raiseRadius = radius;
                 mod.m_settings.m_raiseDelta = (float)args[0];
-                mod.m_settings.m_raisePower = 0.01f;
+                mod.m_settings.m_raisePower = (float)args[1];
 
                 if (op == Operation.Lower)
                     mod.m_settings.m_raiseDelta *= -1f;

--- a/src/CommandHandler.cs
+++ b/src/CommandHandler.cs
@@ -819,6 +819,11 @@ namespace Gungnir
                 Logger.Error("Radius must be greater than 0.", true);
                 return;
             }
+            else if (radius > 50f)
+            {
+                Logger.Error("To avoid crashing your or another player's game, your radius will be clamped to 50.", true);
+                radius = 50f;
+            }
 
             Ground.Level(Player.m_localPlayer.transform.position, radius);
             Logger.Log($"Terrain within {radius.ToString().WithColor(Logger.GoodColor)} meter(s) leveled.", true);
@@ -831,6 +836,11 @@ namespace Gungnir
             {
                 Logger.Error("Radius must be greater than 0.", true);
                 return;
+            }
+            else if (radius > 50f)
+            {
+                Logger.Error("To avoid crashing your or another player's game, your radius will be clamped to 50.", true);
+                radius = 50f;
             }
 
             if (depth <= 0f)
@@ -857,6 +867,11 @@ namespace Gungnir
                 Logger.Error("Radius must be greater than 0.", true);
                 return;
             }
+            else if (radius > 50f)
+            {
+                Logger.Error("To avoid crashing your or another player's game, your radius will be clamped to 50.", true);
+                radius = 50f;
+            }
 
             if (!Enum.TryParse(paintType, true, out TerrainModifier.PaintType type))
             {
@@ -875,6 +890,11 @@ namespace Gungnir
             {
                 Logger.Error("Radius must be greater than 0.", true);
                 return;
+            }
+            else if (radius > 50f)
+            {
+                Logger.Error("To avoid crashing your or another player's game, your radius will be clamped to 50.", true);
+                radius = 50f;
             }
 
             if (height <= 0f)
@@ -901,6 +921,11 @@ namespace Gungnir
                 Logger.Error("Radius must be greater than 0.", true);
                 return;
             }
+            else if (radius > 50f)
+            {
+                Logger.Error("To avoid crashing your or another player's game, your radius will be clamped to 50.", true);
+                radius = 50f;
+            }
 
             Ground.Reset(Player.m_localPlayer.transform.position, radius);
             Logger.Log($"Terrain within {radius.ToString().WithColor(Logger.GoodColor)} meter(s) reset.", true);
@@ -913,6 +938,11 @@ namespace Gungnir
             {
                 Logger.Error("Radius must be greater than 0.", true);
                 return;
+            }
+            else if (radius > 50f)
+            {
+                Logger.Error("To avoid crashing your or another player's game, your radius will be clamped to 50.", true);
+                radius = 50f;
             }
 
             if (strength <= 0f)

--- a/src/Gungnir.cs
+++ b/src/Gungnir.cs
@@ -16,7 +16,7 @@ namespace Gungnir
         public const string ModName    = "Gungnir";
         public const string ModOrg     = "zamboni";
         public const string ModGUID    = ModOrg + "." + ModName;
-        public const string ModVersion = "1.2.3";
+        public const string ModVersion = "1.3.0";
 
         private readonly Harmony m_harmony = new Harmony(ModGUID);
         private CommandHandler   m_handler = new CommandHandler();
@@ -106,7 +106,13 @@ namespace Gungnir
 
         void Update()
         {
-            if (Console.IsVisible() || (Chat.instance != null && Chat.instance.HasFocus()))
+            // Disable keybinds while in text inputs or menus.
+            if (Console.IsVisible() ||
+                (Chat.instance != null && Chat.instance.HasFocus()) ||
+                TextInput.IsVisible() ||
+                Minimap.InTextInput() ||
+                Menu.IsVisible() ||
+                InventoryGui.IsVisible())
                 return;
 
             foreach (KeyValuePair<KeyCode, string> pair in m_binds)

--- a/src/Gungnir.cs
+++ b/src/Gungnir.cs
@@ -16,7 +16,7 @@ namespace Gungnir
         public const string ModName    = "Gungnir";
         public const string ModOrg     = "zamboni";
         public const string ModGUID    = ModOrg + "." + ModName;
-        public const string ModVersion = "1.2.1";
+        public const string ModVersion = "1.2.3";
 
         private readonly Harmony m_harmony = new Harmony(ModGUID);
         private CommandHandler   m_handler = new CommandHandler();


### PR DESCRIPTION
Adds all the terrain modification commands I could think of.
/traise
/tlower
/tlevel
/tsmooth
/treset

Adds /puke

Prevents keybinds from executing in more menus/typing scenarios.

Closes #2